### PR TITLE
Update mass_hallucination.dm

### DIFF
--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/mass_hallucination
 	name = "Mass Hallucination"
 	typepath = /datum/round_event/mass_hallucination
-	weight = 7
+	weight = 0
 	max_occurrences = 2
 	min_players = 1
 


### PR DESCRIPTION
🆑 PopNotes
fix: The Mass Hallucination random event is temporarily out of rotation due to causing crashes.
/🆑

This should be a temporary change, revert once the hallucination crash bug is squashed.